### PR TITLE
fix: remove hostname from pagination url if present

### DIFF
--- a/lib/graph-service.js
+++ b/lib/graph-service.js
@@ -54,6 +54,11 @@ class GraphService extends HttpsService {
       results = results.concat(data.value);
       path = data['@odata.nextLink'] || data['odata.nextLink'] || null;
       if (path) {
+        // If the pagination url includes the hostname it is removed
+        let match = `https://${this.host}/${this.version}`;
+        if (path.startsWith(match)) {
+          path = path.split(match)[1];
+        }
         return this._all(path, null, results);
       } else {
         response.data = results;


### PR DESCRIPTION
The pagination URLs now include the full hostname -- this breaks the _all call since https-service uses the appends the path to the host configured when instantiated. 

Close #8 